### PR TITLE
Add basic gamification for todo tasks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,63 @@
 import { useState } from "react";
-// import reactLogo from "./assets/react.svg";
-// import viteLogo from "/vite.svg";
 import "./App.css";
+
+interface Task {
+  id: number;
+  text: string;
+  completed: boolean;
+}
 
 function App() {
   const [text, setText] = useState("");
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  const addTask = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    const newTask: Task = { id: Date.now(), text, completed: false };
+    setTasks((prev) => [...prev, newTask]);
+    setText("");
+  };
+
+  const toggleTask = (id: number) => {
+    setTasks((prev) =>
+      prev.map((task) =>
+        task.id === id ? { ...task, completed: !task.completed } : task
+      )
+    );
+  };
+
+  const points = tasks.filter((task) => task.completed).length * 10;
 
   return (
-    <div>
-      <form onSubmit={(e) => e.preventDefault()}>
-        <input type="text" value={text} onChange={(e) => e.preventDefault()} />
+    <div className="App">
+      <h1>ToDo List</h1>
+      <p>ポイント: {points}</p>
+      <form onSubmit={addTask}>
         <input
-          type="submit"
-          value="追加"
+          type="text"
+          value={text}
           onChange={(e) => setText(e.target.value)}
+          placeholder="タスクを追加"
         />
+        <button type="submit">追加</button>
       </form>
-
-      <p>{text}</p>
+      <ul>
+        {tasks.map((task) => (
+          <li key={task.id}>
+            <label>
+              <input
+                type="checkbox"
+                checked={task.completed}
+                onChange={() => toggleTask(task.id)}
+              />
+              <span style={{ textDecoration: task.completed ? "line-through" : "none" }}>
+                {task.text}
+              </span>
+            </label>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- convert app to manage list of tasks
- display points for completed tasks to introduce gamification

## Testing
- `npm test` *(fails: Missing script: "test"*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ebdf407488328af4d7648fcb9c0f7