### PR TITLE
feat: use openai client for task suggestions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_OPENAI_API_KEY=your_openai_api_key_here

--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+## AI task suggestions
+
+This project can suggest new to-do items using OpenAI. To enable this feature, copy `.env.example` to `.env` and set your API key:
+
+```bash
+cp .env.example .env
+# edit .env and add your key
+```
+
+The key is loaded from `VITE_OPENAI_API_KEY`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material'
 import DeleteIcon from '@mui/icons-material/Delete'
 import './App.css'
+import OpenAI from 'openai'
 
 interface Task {
   id: number
@@ -67,28 +68,29 @@ function App() {
   }
 
   const suggestTask = async () => {
+    if (!import.meta.env.VITE_OPENAI_API_KEY) {
+      alert('OpenAI API key is not configured.')
+      return
+    }
     setLoadingAI(true)
     try {
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
-        },
-        body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
-          messages: [
-            { role: 'system', content: 'You are a helpful to-do assistant.' },
-            { role: 'user', content: 'Give me one short to-do item.' },
-          ],
-          max_tokens: 30,
-        }),
+      const client = new OpenAI({
+        apiKey: import.meta.env.VITE_OPENAI_API_KEY,
+        dangerouslyAllowBrowser: true,
       })
-      const data = await res.json()
+      const data = await client.chat.completions.create({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'You are a helpful to-do assistant.' },
+          { role: 'user', content: 'Give me one short to-do item.' },
+        ],
+        max_tokens: 30,
+      })
       const suggestion = data.choices?.[0]?.message?.content?.trim()
       if (suggestion) setText(suggestion)
     } catch (err) {
       console.error(err)
+      alert('AI suggestion failed')
     } finally {
       setLoadingAI(false)
     }


### PR DESCRIPTION
## Summary
- integrate OpenAI client for AI-generated task suggestions
- add `.env.example` and docs for API key configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npx eslint --config .eslintrc.cjs .` *(fails: A config object is using the "root" key)*
- `npx -y eslint@8 --config .eslintrc.cjs .` *(fails: 403 Forbidden fetching eslint)*

------
https://chatgpt.com/codex/tasks/task_e_689ecae5e7388328aea7634691014cdb